### PR TITLE
ci: Add Github action to build the book and add them to releases page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Build perfbook PDFs
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Allows manual trigger
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt install -y make texlive texlive-font-utils texlive-fonts-extra \
+          texlive-pstricks texlive-science fig2ps graphviz inkscape gnuplot 
+
+    - name: Install Steel City Comic font
+      run:         
+        mkdir -p $HOME/.local/share/fonts/
+        
+        cp fonts/steel-city-comic.regular.ttf $HOME/.local/share/fonts/steel-city-comic.regular.ttf
+        
+        fc-cache -fv
+                        
+    - name: Build regular PDF
+      run: make
+        
+    - name: Build ebook PDF
+      run: make clean eb
+        
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          perfbook.pdf
+          perfbook-eb.pdf
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload PDFs as artifacts (for manual runs)
+      if: "!startsWith(github.ref, 'refs/tags/')"
+      uses: actions/upload-artifact@v4.5.0
+      with:
+        name: perfbook-pdfs
+        path: |
+          perfbook.pdf
+          perfbook-eb.pdf


### PR DESCRIPTION
This will build the the default target and kindle book target, on both triggering the action manually or creating a release.

![image](https://github.com/user-attachments/assets/111895f2-7330-498e-8e30-bbeab554f348)

When running manually

![image](https://github.com/user-attachments/assets/28d9b39d-50ae-4bcd-b524-dd942297e2a4)

We can add more targets to build too but these are the only ones I use and familiar with.

Also thanks for valuable resource, I am enjoy reading it a lot.

`Signed-off-by: Omar El Khatib <elkhatibomar@outlook.com>`