### PR TITLE
cpu/overheads.tex: Fix terminology typo in L3 cache description

### DIFF
--- a/cpu/overheads.tex
+++ b/cpu/overheads.tex
@@ -551,7 +551,7 @@ this system.
 Third, again referring to the figure, the caches are organized as
 a hardware hash table with a limited number of items per bucket.
 For example, the raw size of the L3 cache (``Size'') is almost 40\,MB, but each
-bucket (``Line'') can only hold 11 blocks of memory (``Ways''), each
+bucket (``Sets'') can only hold 11 blocks of memory (``Ways''), each
 of which can be at most 64 bytes (``Line Size'').
 This means that only 12 bytes of memory (admittedly at carefully chosen
 addresses) are required to overflow this 40\,MB cache.


### PR DESCRIPTION
In the description of L3 cache organization, the text incorrectly referred to "bucket" as "Line" in parentheses. Based on the  accompanying table, this should refer to the "Sets" column. 

This commit changes `(``Line'')"` to `"(``Sets'')` to match the table headers and standard cache terminology.

Signed-off-by: npc1054657282 <ly1054657282@gmail.com>